### PR TITLE
Fix for #58. af translation tweaked - Shortened two translation strings.

### DIFF
--- a/assets/translations/af.json
+++ b/assets/translations/af.json
@@ -12,14 +12,14 @@
     "win": "Wen!",
     "wins": "wen!",
     "won": "het gewen!",
-    "nobody_wins": "Niemand wen nie 😲",
+    "nobody_wins": "Geen wenner😲",
     "thinking": "Besig...",
     "player_no_name": "Geen naam"
   },
   "menu": {
     "online_multiplayer": "AANLYN OPPONENT",
     "coming_soon": "Binnekort!",
-    "how_to_play": "Hoe om te speel",
+    "how_to_play": "Spel hulp",
     "easy": "MAKLIK",
     "medium": "MEDIUM",
     "hard": "MOEILIK",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.1.0+4
+version: 1.1.0+6
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Selected shorter translations for two strings.