### PR TITLE
Fix web crash

### DIFF
--- a/lib/utils/audio.dart
+++ b/lib/utils/audio.dart
@@ -1,17 +1,19 @@
 import 'package:audioplayers/audio_cache.dart';
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/foundation.dart';
 
 enum GameSounds { PlacingPiece, InnerGridWin, GameWon, GameLost }
 enum UISounds { ButtonClick }
 
 abstract class BaseAudio {
-  final AudioCache player = AudioCache(prefix: 'assets/audio/');
+  final AudioCache player = kIsWeb ? null : AudioCache(prefix: 'assets/audio/');
 
   void preloadSounds();
 
-  bool isMuted = false;
+  bool isMuted = kIsWeb ? true : false;
 
   void switchMute() {
+    if (kIsWeb) return;
     isMuted = !isMuted;
   }
 }
@@ -19,6 +21,7 @@ abstract class BaseAudio {
 class GameAudio extends BaseAudio {
   @override
   void preloadSounds() {
+    if (kIsWeb) return;
     player.loadAll([
       'piece_placement.mp3',
       'success.mp3',
@@ -28,6 +31,7 @@ class GameAudio extends BaseAudio {
   }
 
   void playSound(GameSounds soundEvent) async {
+    if (kIsWeb) return;
     switch (soundEvent) {
       case GameSounds.PlacingPiece:
         await player.play(
@@ -53,7 +57,7 @@ class GameAudio extends BaseAudio {
         );
         break;
       case GameSounds.GameLost:
-        // Ned to wait for innter grid win the finish playing
+        // Ned to wait for inner grid win the finish playing
         await Future.delayed(const Duration(milliseconds: 500));
         await player.play(
           'game_over.mp3',
@@ -68,10 +72,12 @@ class GameAudio extends BaseAudio {
 class UIAudio extends BaseAudio {
   @override
   void preloadSounds() {
+    if (kIsWeb) return;
     player.loadAll(['button_click.mp3']);
   }
 
   void playSound(UISounds uiSound) async {
+    if (kIsWeb) return;
     switch (uiSound) {
       case UISounds.ButtonClick:
         await player.play(


### PR DESCRIPTION
audioplayers library related - playing sounds must be done with different class https://github.com/luanpotter/audioplayers#audiocache - AudioCache not supported on web

for now the sounds do not play on the web, but at least the app works and starts normally

Fixes #94 